### PR TITLE
開発時のPortを変更可能に

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "0.0.1",
   "description": "",
   "main": "index.js",
+  "config": {
+    "nuxt": {
+      "host": "0.0.0.0",
+      "port": "3000"
+    }
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "nuxt",

--- a/readme.md
+++ b/readme.md
@@ -74,3 +74,16 @@ https://ja.nuxtjs.org/guide/directory-structure#%E3%83%87%E3%82%A3%E3%83%AC%E3%8
 `en` -> `/en/sponsor`
 
 リンクパスは `nuxt-link(:to="$i18n.path('sponsor')" exact)` のように対応`(HeaderNavi参照
+
+# その他
+## 開発環境のPort変更
+
+package.json
+
+```json
+"config": {
+  "nuxt": {
+    "host": "0.0.0.0",
+    "port": "4000" // ここを変更
+  }
+},


### PR DESCRIPTION
## このPRはなにか
- 開発時のポート3000はrails開発などしていると埋まっていることが多い
- packege.json でportを変更できるようにしました

## どうやって実装したか
- nuxt公式を参考にしました。[ホストとポート番号 - Nuxt.js](https://ja.nuxtjs.org/faq/host-port/)

## コメント
- 「このやり方が最高」ということではなく議論ベースのイメージです
  - 環境変数で十分、という方もいそうな気がしてます
- nuxtを使った開発をしたことがあるわけではないので、もっと良いpracticeがあれば教えてください
- packege.jsonに書くとgitignoreできないので微妙な気もしてます
- [dotenv](https://www.npmjs.com/package/dotenv)を使うやり方もありかも
