### PR TITLE
main.sassからUIkitのテーマをロード/カスタマイズするように変更。

### DIFF
--- a/assets/css/main.sass
+++ b/assets/css/main.sass
@@ -1,0 +1,56 @@
+@import url(//fonts.googleapis.com/earlyaccess/notosansjp.css)
+
+/**
+ * uikit-theme variables
+ **/
+// font-family
+$global-font-family: "Noto Sans CJK JP", sans-serif
+
+//breakpoints
+$breakpoint-small: 640px !default
+$breakpoint-medium: 960px !default
+$breakpoint-large: 1300px !default
+$breakpoint-xlarge: 1600px !default
+
+// uk-container's width
+$container-max-width: 1300px !default
+
+// uk-container padding (pc)
+$global-medium-gutter: 20px
+
+// uk-container padding (sp)
+$container-padding-horizontal: 0 !default
+
+// body
+$global-color: #666 !default
+$global-inverse-color: #fff !default
+$base-body-color: $global-color !default
+
+// link-setting
+$global-link-color: #29abe2 !default
+$global-link-color: #29abe2 !default
+$base-link-color: $global-link-color !default
+$base-link-text-decoration: none !default
+$global-link-hover-color: #00dfd8 !default
+$base-link-hover-color: $global-link-hover-color !default
+$base-link-hover-text-decoration: none !default
+
+// h2
+$base-h2-font-size: 50px !default
+$base-h2-line-height: 1.3 !default
+
+
+/**
+ * common elements setting
+ **/
+// h2 title
+h2.regular-ttl
+  color: #4a4a4a
+  font-weight: 300
+
+// gradation-color-box
+
+
+@import "uikit/src/scss/variables-theme.scss"
+@import "uikit/src/scss/mixins-theme.scss"
+@import "uikit/src/scss/uikit-theme.scss"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -22,7 +22,7 @@ module.exports = {
     vendor: ['uikit']
   },
   css: [
-    'uikit/dist/css/uikit.min.css',
+    { src: '~assets/css/main.sass', lang: 'sass' }
   ],
   router: {
     middleware: 'i18n'


### PR DESCRIPTION
# 変更内容
main.sassよりUIkitのテーマをインポートし、設定するようにしました。  
必要そうなUIkitの変数は出してありますが、まだ足りないと感じた場合はuikitの本体モジュール側にあるsrc/scss/variables-theme.scss等から参照して追加をお願いします。  
また、uikitテーマでなくても、全ページ共通パーツのスタイルもmain.sassにいれてください。  

それ以下は直近位置にsassを置いてスタイリングをお願いします。  
- ページ内共通：pages/_lang/xxx/yyy.sass (ページ内コンポーネントをくるんでいるdivに#pycon-xxxなるID付けを推奨します
- コンポーネント内スタイル：components/xxx/yyy.sass