### PR TITLE
fix email address about footer

### DIFF
--- a/components/GlobalFooter/footer.pug
+++ b/components/GlobalFooter/footer.pug
@@ -8,7 +8,7 @@ footer#global-footer.uk-section.uk-section-default.uk-container.uk-flex(class="u
         p#contact-mail-address PyCon JP 2018 in Tokyo is a production of the
             a(href='http://www.pycon.jp/', target='blank') PyCon JP Committee
             |. Contact :
-            a(href='mailto:pycon@pycon.jp') pycon@pycon.jp
+            a(href='mailto:pyconjp@pycon.jp') pyconjp@pycon.jp
 
         div#footer-creative-commons.uk-flex.uk-flex-middle
             p


### PR DESCRIPTION
https://pycon.jp/2018/
のメールアドレスが間違っているとDMで連絡があったので修正。