### PR TITLE
nuxt-server向け英語版リンク対応（暫定）

### DIFF
--- a/assets/css/main.sass
+++ b/assets/css/main.sass
@@ -1,4 +1,4 @@
-//@import url(https://fonts.googleapis.com/earlyaccess/notosansjp.css)
+@import url(https://fonts.googleapis.com/earlyaccess/notosansjp.css)
 /**
  * common elements setting
  **/

--- a/assets/css/main.sass
+++ b/assets/css/main.sass
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/earlyaccess/notosansjp.css)
+//@import url(https://fonts.googleapis.com/earlyaccess/notosansjp.css)
 /**
  * common elements setting
  **/

--- a/components/GlobalHeader/header.pug
+++ b/components/GlobalHeader/header.pug
@@ -10,8 +10,8 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
               li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
                   nuxt-link(:to="$i18n.path('code-of-conduct')" exact) {{ $t('header.navi.code_of_conduct') }}
               li
-                  a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
-                  nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
+                  a(:href="getLangPath()") {{ $t('header.navi.lang') }}
+                  //nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
     div#mobile-nav.uk-container(class="uk-hidden@s").uk-flex
         .uk-offcanvas-content
@@ -31,7 +31,8 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
                     li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
                         nuxt-link(:to="$i18n.path('code-of-conduct')" exact)  {{ $t('header.navi.code_of_conduct') }}
                     li
-                      nuxt-link(:to="getLangPath()" exact) {{ $t('header.navi.lang') }}
+                      a(:href="getLangPath()") {{ $t('header.navi.lang') }}
+                      //nuxt-link(:to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
         nuxt-link(:to="$i18n.path('')" exact)
             img(src='~/static/top/firstview-logo.png', alt='PyConJP 2018')

--- a/components/GlobalHeader/header.pug
+++ b/components/GlobalHeader/header.pug
@@ -1,19 +1,15 @@
 header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk-navbar-sticky; bottom: #transparent-sticky-navbar" uk-navbar)
     div#pc-nav.uk-container.uk-flex.uk-flex-middle(class="uk-visible@s")
       h1
-        //a(:href="getPath()")
         nuxt-link(:to="$i18n.path('')" exact)
             img(src='~/static/common/global-header-logo.png', alt='PyConJP 2018' width='188' height='26')
       nav#global_nav.uk-navbar-right
           ul.uk-navbar-nav
               li(v-bind:class="{'uk-active':isActive('sponsor')}")
                   nuxt-link(:to="$i18n.path('sponsor')" exact) {{ $t('header.navi.sponsor') }}
-                  //a(:href="getPath('sponsor')")
               li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
                   nuxt-link(:to="$i18n.path('code-of-conduct')" exact) {{ $t('header.navi.code_of_conduct') }}
-                  //a(:href="getPath('code-of-conduct')")
               li
-                  //a(:href="getLangPath()") {{ $t('header.navi.lang') }}
                   a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
                   nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
@@ -28,20 +24,14 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
               button.uk-offcanvas-close(tyle="button" uk-close)
               nav#global-nav-sp
                   ul
+                    li(v-bind:class="{'uk-active':isActive('index')}")
+                        nuxt-link(:to="$i18n.path('')" exact) {{ $t('header.navi.top.top') }}
                     li(v-bind:class="{'uk-active':isActive('sponsor')}")
-                        a(:href="getPath()")  {{ $t('header.navi.top.top') }}
-                        li(v-bind:class="{'uk-active':isActive('sponsor')}")
-                        //nuxt-link(:to="$i18n.path('sponsor')" exact)
-                        a(:href="getPath('sponsor')")
-                            | {{ $t('header.navi.sponsor') }}
+                        nuxt-link(:to="$i18n.path('sponsor')" exact) {{ $t('header.navi.sponsor') }}
                     li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
-                        //nuxt-link(:to="$i18n.path('code-of-conduct')" exact)
-                        a(:href="getPath('code-of-conduct')")
-                            | {{ $t('header.navi.code_of_conduct') }}
-                    //li
-                    //    a(:href="getLangPath()") {{ $t('header.navi.lang') }}
-                        //a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
-                        //nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
+                        nuxt-link(:to="$i18n.path('code-of-conduct')" exact)  {{ $t('header.navi.code_of_conduct') }}
+                    li
+                      nuxt-link(:to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
-        a(:href="getPath()")
+        nuxt-link(:to="$i18n.path('')" exact)
             img(src='~/static/top/firstview-logo.png', alt='PyConJP 2018')

--- a/components/GlobalHeader/header.pug
+++ b/components/GlobalHeader/header.pug
@@ -13,9 +13,8 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
                   //nuxt-link(:to="$i18n.path('code-of-conduct')" exact)
                   a(:href="getPath('code-of-conduct')")
                       | {{ $t('header.navi.code_of_conduct') }}
-              //li
-              //    a(:href="getLangPath()") {{ $t('header.navi.lang') }}
-
+              li
+                  a(:href="getLangPath()") {{ $t('header.navi.lang') }}
                   //a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
                   //nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 

--- a/components/GlobalHeader/header.pug
+++ b/components/GlobalHeader/header.pug
@@ -1,22 +1,21 @@
 header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk-navbar-sticky; bottom: #transparent-sticky-navbar" uk-navbar)
     div#pc-nav.uk-container.uk-flex.uk-flex-middle(class="uk-visible@s")
       h1
-        a(:href="getPath()")
+        //a(:href="getPath()")
+        nuxt-link(:to="$i18n.path('')" exact)
             img(src='~/static/common/global-header-logo.png', alt='PyConJP 2018' width='188' height='26')
       nav#global_nav.uk-navbar-right
           ul.uk-navbar-nav
               li(v-bind:class="{'uk-active':isActive('sponsor')}")
-                  //nuxt-link(:to="$i18n.path('sponsor')" exact)
-                  a(:href="getPath('sponsor')")
-                      | {{ $t('header.navi.sponsor') }}
+                  nuxt-link(:to="$i18n.path('sponsor')" exact) {{ $t('header.navi.sponsor') }}
+                  //a(:href="getPath('sponsor')")
               li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
-                  //nuxt-link(:to="$i18n.path('code-of-conduct')" exact)
-                  a(:href="getPath('code-of-conduct')")
-                      | {{ $t('header.navi.code_of_conduct') }}
+                  nuxt-link(:to="$i18n.path('code-of-conduct')" exact) {{ $t('header.navi.code_of_conduct') }}
+                  //a(:href="getPath('code-of-conduct')")
               li
-                  a(:href="getLangPath()") {{ $t('header.navi.lang') }}
-                  //a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
-                  //nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
+                  //a(:href="getLangPath()") {{ $t('header.navi.lang') }}
+                  a(v-if="isActive('index')" :href="getLangPath()") {{ $t('header.navi.lang') }}
+                  nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
     div#mobile-nav.uk-container(class="uk-hidden@s").uk-flex
         .uk-offcanvas-content

--- a/components/GlobalHeader/index.vue
+++ b/components/GlobalHeader/index.vue
@@ -20,7 +20,7 @@
         //const _path =  '/' + path
         //const __path = (this.$i18n.locale === 'ja')? "/en" + _path: _path
         //return process.env.baseUrl + __path;
-        return (this.$i18n.locale === 'en') ? this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/en` + this.$route.fullPath;
+        return (this.$i18n.locale === 'en') ? '/2018' + this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/2018/en` + this.$route.fullPath;
       },
       getPath(path=""){
         // console.log(process.env.baseUrl);

--- a/components/GlobalHeader/index.vue
+++ b/components/GlobalHeader/index.vue
@@ -20,7 +20,7 @@
         //const _path =  '/' + path
         //const __path = (this.$i18n.locale === 'ja')? "/en" + _path: _path
         //return process.env.baseUrl + __path;
-        return (this.$i18n.locale === 'en') ? '/2018' + this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/2018/en` + this.$route.fullPath;
+        return (this.$i18n.locale === 'en') ? '/_2018' + this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/_2018/en` + this.$route.fullPath;
       },
       getPath(path=""){
         // console.log(process.env.baseUrl);

--- a/components/GlobalHeader/index.vue
+++ b/components/GlobalHeader/index.vue
@@ -17,9 +17,10 @@
       getLangPath (path="") {
         // const _path = (this.$i18n.locale === 'en')? this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/en` + this.$route.fullPath;
         // return process.env.baseUrl + _path;
-        const _path =  '/' + path
-        const __path = (this.$i18n.locale === 'ja')? "/en" + _path: _path
-        return process.env.baseUrl + __path;
+        //const _path =  '/' + path
+        //const __path = (this.$i18n.locale === 'ja')? "/en" + _path: _path
+        //return process.env.baseUrl + __path;
+        return (this.$i18n.locale === 'en') ? this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/en` + this.$route.fullPath;
       },
       getPath(path=""){
         // console.log(process.env.baseUrl);

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,18 +30,19 @@ module.exports = {
     { src: '~/assets/css/main.sass', lang: 'sass' },
   ],
   router: {
-    middleware: 'i18n'
+    middleware: 'i18n',
+    base: '/2018/'
   },
   plugins: ['~/plugins/i18n.js'],
   generate: {
     minify: {
       collapseWhitespace: false
     },
-    routes: ['/', 'en']
+    routes: ['/','/code-of-conduct','/sponsor','/en','/en/code-of-conduct','/en/sponsor']
   },
   env: {
-    //baseUrl: '',
-    baseUrl: 'http://nar.matz:8080/2018',
+    baseUrl: '',
+    //baseUrl: 'http://nar.matz:8080/2018',
     sponsorApiEndpoint: 'https://script.google.com/macros/s/AKfycbyKmE6Ew9aWmOnj3VSwn435T8cx8kF0SkJb9fN7_PdE_ME2QpqP/exec'
   },
   modules: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -31,7 +31,7 @@ module.exports = {
   ],
   router: {
     middleware: 'i18n',
-    base: '/2018/'
+    base: '/_2018/'
   },
   plugins: ['~/plugins/i18n.js'],
   generate: {
@@ -42,7 +42,6 @@ module.exports = {
   },
   env: {
     baseUrl: '',
-    //baseUrl: 'http://nar.matz:8080/2018',
     sponsorApiEndpoint: 'https://script.google.com/macros/s/AKfycbyKmE6Ew9aWmOnj3VSwn435T8cx8kF0SkJb9fN7_PdE_ME2QpqP/exec'
   },
   modules: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,7 +41,7 @@ module.exports = {
   },
   env: {
     //baseUrl: '',
-    baseUrl: baseUrl,
+    baseUrl: 'http://nar.matz:8080/2018',
     sponsorApiEndpoint: 'https://script.google.com/macros/s/AKfycbyKmE6Ew9aWmOnj3VSwn435T8cx8kF0SkJb9fN7_PdE_ME2QpqP/exec'
   },
   modules: [

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,7 +37,7 @@ module.exports = {
     minify: {
       collapseWhitespace: false
     },
-    routes: ['/', 'code-of-conduct', 'en', 'en/code-of-conduct']
+    routes: ['/', 'en']
   },
   env: {
     //baseUrl: '',

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /_2018/


### PR DESCRIPTION
# 変更内容
nuxtをテンポラリーサーバで稼働させnginxからリバースプロキシをかけた際に、ルートURLが/2018/ではない為リンク関係がおかしくなる点について検証のための暫定修正をしました。

- nuxt.config.jsにてbase:'/2018'としてrouterのベースURLを変更
このためlocalhostの検証においても
localhost:4000/ ->エラー
localhost:4000/2018/ ->トップページ他コンテンツ表示
となりますのでご注意ください。
（テンポラリサーバ側では、取り合えず/に対するリクエストの処置はいらないかな…と思っています）

- globalheaderのリンクについてgetpath()ではなくnuxt-linkに切り戻してみています


## 未対応事項
- スマホ表示時のグローバルナビゲーション（ドロワー）がリンクをクリックしても閉じない（nuxt-linkに修正した為の模様）
- トップページのスポンサー一覧表示について、一回表示させる→他のページに移動→再び戻る（ブラウザバック等含む）と縮小されて表示されている件（リロードすると直ります。CSS部分等を確認中）