### PR TITLE
CSS／モバイル版グローバルナビゲーション不具合修正

### DIFF
--- a/assets/css/main.sass
+++ b/assets/css/main.sass
@@ -3,6 +3,9 @@
  * common elements setting
  **/
 .outer-container
+    *
+      box-sizing: border-box
+
     // h2 title
     h2
       color: #4a4a4a

--- a/components/GlobalHeader/header.pug
+++ b/components/GlobalHeader/header.pug
@@ -1,8 +1,8 @@
 header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk-navbar-sticky; bottom: #transparent-sticky-navbar" uk-navbar)
     div#pc-nav.uk-container.uk-flex.uk-flex-middle(class="uk-visible@s")
-      h1
-        nuxt-link(:to="$i18n.path('')" exact)
-            img(src='~/static/common/global-header-logo.png', alt='PyConJP 2018' width='188' height='26')
+      nuxt-link(:to="$i18n.path('')" exact tag="h1")
+        a
+          img(src='~/static/common/global-header-logo.png', alt='PyConJP 2018' width='188' height='26')
       nav#global_nav.uk-navbar-right
           ul.uk-navbar-nav
               li(v-bind:class="{'uk-active':isActive('sponsor')}")
@@ -11,7 +11,6 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
                   nuxt-link(:to="$i18n.path('code-of-conduct')" exact) {{ $t('header.navi.code_of_conduct') }}
               li
                   a(:href="getLangPath()") {{ $t('header.navi.lang') }}
-                  //nuxt-link(v-else :to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
     div#mobile-nav.uk-container(class="uk-hidden@s").uk-flex
         .uk-offcanvas-content
@@ -24,15 +23,14 @@ header#global-header(uk-sticky="sel-target: .uk-navbar-container; cls-active: uk
               button.uk-offcanvas-close(tyle="button" uk-close)
               nav#global-nav-sp
                   ul
-                    li(v-bind:class="{'uk-active':isActive('index')}")
-                        nuxt-link(:to="$i18n.path('')" exact) {{ $t('header.navi.top.top') }}
-                    li(v-bind:class="{'uk-active':isActive('sponsor')}")
-                        nuxt-link(:to="$i18n.path('sponsor')" exact) {{ $t('header.navi.sponsor') }}
-                    li(v-bind:class="{'uk-active':isActive('code-of-conduct')}")
-                        nuxt-link(:to="$i18n.path('code-of-conduct')" exact)  {{ $t('header.navi.code_of_conduct') }}
+                    nuxt-link(:to="$i18n.path('')" exact tag="li")
+                        a.uk-offcanvas-close {{ $t('header.navi.top.top') }}
+                    nuxt-link(:to="$i18n.path('sponsor')" exact tag="li")
+                        a.uk-offcanvas-close {{ $t('header.navi.sponsor') }}
+                    nuxt-link(:to="$i18n.path('code-of-conduct')" exact tag="li")
+                        a.uk-offcanvas-close  {{ $t('header.navi.code_of_conduct') }}
                     li
                       a(:href="getLangPath()") {{ $t('header.navi.lang') }}
-                      //nuxt-link(:to="getLangPath()" exact) {{ $t('header.navi.lang') }}
 
         nuxt-link(:to="$i18n.path('')" exact)
             img(src='~/static/top/firstview-logo.png', alt='PyConJP 2018')

--- a/components/GlobalHeader/header.sass
+++ b/components/GlobalHeader/header.sass
@@ -51,5 +51,7 @@ nav#global-nav-sp
     li
       margin-bottom: .5rem
       a
+        position: static
         font-size: 16px
         font-weight: 300
+        padding: 0

--- a/components/GlobalHeader/index.vue
+++ b/components/GlobalHeader/index.vue
@@ -3,6 +3,9 @@
 <script>
   export default {
     name: 'global-header',
+    data: {
+      hideCanvas: false
+    },
     methods: {
       isActive (route_name) {
         // console.log(this.$nuxt.$route.name);
@@ -20,14 +23,18 @@
         //const _path =  '/' + path
         //const __path = (this.$i18n.locale === 'ja')? "/en" + _path: _path
         //return process.env.baseUrl + __path;
-        return (this.$i18n.locale === 'en') ? '/_2018' + this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/_2018/en` + this.$route.fullPath;
+        return (this.$i18n.locale === 'en') ? '/_2018' + this.$route.fullPath.replace(/^\/[^\/]+/, '') : `/_2018/en` + this.$route.fullPath
       },
       getPath(path=""){
         // console.log(process.env.baseUrl);
         // Todo::Topへのリンクが重いための暫定処理
         const _path =  '/' + path
         const __path = (this.$i18n.locale === 'en')? "/" + this.$i18n.locale + _path: _path
-        return process.env.baseUrl + __path;
+        //return process.env.baseUrl + __path;
+        return this.$route.path + path
+      },
+      canvasClose(e){
+        //.offcanvas('#').hide()
       },
     }
   }

--- a/components/TopSponsor/sponsor.sass
+++ b/components/TopSponsor/sponsor.sass
@@ -22,8 +22,8 @@ section#TopSponsor
       list-style: none
 
       li
-        width: 150px
-        height: 100px
+        width: 180px
+        height: 130px
         border: solid 1px #d0d0d0
         padding: 15px
         margin-right: 1.7rem

--- a/pages/_lang/_top/index.sass
+++ b/pages/_lang/_top/index.sass
@@ -1,6 +1,3 @@
-$breakpoint-xsmall-max: 639px
-$pycon-global-footer-bg-color: #f6f6f6
-
 #pycon-top
   div.uk-container-expand
     background-color: $pycon-global-footer-bg-color

--- a/pages/_lang/code-of-conduct/index.pug
+++ b/pages/_lang/code-of-conduct/index.pug
@@ -1,5 +1,5 @@
 div#CodeOfConduct
     div.uk-container
-        section.uk-section.uk-section-default
+        section#code-of-conduct.uk-section.uk-section-default
             h2 {{ $t('code_of_conduct.title') }}
             p(v-for="word in $t('code_of_conduct.body')") {{ word }}

--- a/pages/_lang/code-of-conduct/index.sass
+++ b/pages/_lang/code-of-conduct/index.sass
@@ -1,0 +1,2 @@
+section#code-of-conduct
+  margin: 0 20px

--- a/pages/_lang/code-of-conduct/index.vue
+++ b/pages/_lang/code-of-conduct/index.vue
@@ -10,3 +10,5 @@
     },
   }
 </script>
+
+<style src="./index.sass" lang="sass" />

--- a/pages/_lang/sponsor/index.vue
+++ b/pages/_lang/sponsor/index.vue
@@ -73,9 +73,6 @@ export default {
 </script>
 
 <style lang="sass">
-*
-  box-sizing: border-box
-
 #pycon-sponsor
   margin-top: 3rem
   @media (max-width: $breakpoint-small)


### PR DESCRIPTION
# 変更点
### 1.nuxt-serverでブラウザバックをつかったりするとトップスポンサーのボックスの大きさが縮む件を修正
- sponsorページで「* { box-sizing: border-box }と設定されていた影響でした。main.sassのほうに移動してTopSponsor側のCSSを変更して対応しました


###  2.モバイル表示時のグローバルナビゲーションについて、リンククリックをしても閉じなくなっていたので修正
- もともとはリンクをたどるたびに都度リクエストが飛んでいたので勝手に初期状態に戻っていた（閉じていた）けど、nuxt-linkにより差分だけ描画…みたいになったため「閉じなくなった！」ように見えたようです
- 頭が悪いとおもいつつ、nuxt上でのuikitインスタンスの拾い方が不明だった為、closeクラスをaタグにつけて対応しました