### PR TITLE
Sponsorページ英語対応

### DIFF
--- a/components/Sponsor/Card/mixins/cardMixin.js
+++ b/components/Sponsor/Card/mixins/cardMixin.js
@@ -5,6 +5,15 @@ export default {
       showRecruit: false,
     }
   },
+  methods: {
+    decideLocale: function(attr_base){
+      if(this.$store.state.locale === "en" && this.sponsor[attr_base + '_en']){
+        return this.sponsor[attr_base + '_en']
+      } else {
+        return this.sponsor[attr_base + '_ja']
+      }
+    }
+  },
   computed: {
     imgSrc: function(){
       if (!this.sponsor.imgPath || this.sponsor.imgPath === ""){
@@ -14,19 +23,19 @@ export default {
       }
     },
     name: function(){
-      return this.sponsor.name_ja
+      return this.decideLocale('name')
     },
     siteUrl: function(){
-      return this.sponsor.siteUrl_ja
+      return this.decideLocale('siteUrl')
     },
     desc: function(){
-      return this.sponsor.description_ja
+      return this.decideLocale('description')
     },
     recruitText: function(){
-      return this.sponsor.recruitText_ja
+      return this.decideLocale('recruitText')
     },
     recruitUrl: function(){
-      return this.sponsor.recruitUrl_ja
+      return this.decideLocale('recruitUrl')
     }
   }
 }


### PR DESCRIPTION
## このPRは何か
- スポンサーページ英語対応( /_2018/en/sponsor )

## どうやって実装したか
- `$store.state.locale` を見て"en"でかつ英語情報が入力されていた場合、英語を表示します
- もし英語情報が入力されていなかった場合、日本語を表示します(この仕様で問題ないかは改めてt-jimukyokuに確認します)
- `name_ja, name_en` のように `{attr}_(ja|en)`の形になっているので共通化したメソッドを作ってます


