### PR TITLE
英語版リソースタイポ修正

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -105,7 +105,7 @@
       },
       "first": {
         "date": "September 17th",
-        "name": "Yutaka Matuo",
+        "name": "Yutaka Matsuo",
         "about":[
           "1997年 東京大学工学部電子情報工学科卒業。",
           "2002年 同大学院博士課程修了。博士（工学）。同年より、産業技術総合研究所研究員。",
@@ -118,7 +118,7 @@
       },
       "second": {
         "date": "September 17th",
-        "name": "Koraro Nakayama",
+        "name": "Kotaro Nakayama",
         "about": [
           "東京大学工学系研究科技術経営戦略学専攻 松尾研究室 特任講師。",
           "2007年に大阪大学大学院情報科学研究科博士号取得後、大阪大学情報科学研究科特任研究員、東京大学知の構造化センター助教、講師を経て、現在に至る。",


### PR DESCRIPTION
# 修正点
松尾氏、中山氏両名の英語版のお名前表記にタイポがあったので訂正しました。