### PR TITLE
カンファレンスページモバイル対応

### DIFF
--- a/assets/css/variables.sass
+++ b/assets/css/variables.sass
@@ -102,3 +102,5 @@ $sponsor-1-4-width: 270px
   border-radius: 4px
   background-color: #FFF
   box-shadow: 0 2px 6px 0 rgba(0, 0, 0, .15)
+  @media (max-width: $breakpoint-xsmall-max)
+    width: calc(100% - .8rem)

--- a/components/Event/SessionSummary/index.vue
+++ b/components/Event/SessionSummary/index.vue
@@ -6,7 +6,7 @@
     props: ['talk'],
     computed: {
       langage() {
-        return (this.talk && this.talk.hasOwnProperty('lang')) ?  this.talk.lang : ""
+        return (this.talk && this.talk.hasOwnProperty('lang_of_talk') && this.talk.lang_of_talk !="" ) ?  this.talk.lang_of_talk : "-"
       },
       room() {
         return (this.talk && this.talk.hasOwnProperty('room')) ?  this.talk.room : ""
@@ -20,11 +20,18 @@
       name() {
         return (this.talk && this.talk.hasOwnProperty('name')) ?  this.talk.name : ""
       },
+      level() {
+        return (this.talk && this.talk.hasOwnProperty('audience_level') ) ?  this.talk.audience_level : "-"
+      },
       tags() {
         let tags = []
         if(this.talk && this.talk.hasOwnProperty('tags')){
-            let tagStr = this.talk.tags
+            let tagStr = String(this.talk.tags)
             tags = tagStr.split(',')
+            if(Object.keys(tags).length <= 0 || tags[0] === ""){
+              console.log(tags)
+               tags = false
+              }
         }
         return tags
       }

--- a/components/Event/SessionSummary/summary.pug
+++ b/components/Event/SessionSummary/summary.pug
@@ -5,6 +5,9 @@ div.session-summary.uk-flex.uk-flex-column(v-if="room")
   h3 {{ title }}
   p.name {{ name }}
   p.disc 
-  h4 keywords:
+  dl.talk-property.uk-flex
+    dt.talk-level level :
+    dd(:class="{all: level == 'All', beginner: level == 'Beginner', intermediate: level == 'Intermediate', advanced: level == 'Advanced'}") {{ level }}
+  h4(v-if="tags") keywords :
   ul.tag.uk-flex.uk-flex-wrap
     li( v-for="item in tags") {{ item }}

--- a/components/Event/SessionSummary/summary.sass
+++ b/components/Event/SessionSummary/summary.sass
@@ -2,15 +2,35 @@
 div.session-summary
   @include event-box
   h4
-    margin: .6rem 0 0
+    margin: .2rem 0 .1rem
     font-size: 12px
     color: #9B9B9B
   p
     word-wrap: break-word
-
   p.disc
     margin: .4rem 0 0 0
     font-size: 10px
+
+  dl.talk-property
+    margin: .6rem 0 0
+    dt,dd
+      font-size: 12px
+    dt
+      color: #9B9B9B
+      margin-right: .2rem
+      font-weight: normal
+    dd
+      align-self: center
+      line-height: 120%
+    dd.all
+      border-bottom: 1px solid #29abe2
+    dd.beginner
+      border-bottom: 1px solid #8FBD28
+    dd.intermediate
+      border-bottom: 1px solid #E9D700
+    dd.advanced
+      border-bottom: 1px solid #ea4918
+
   ul
     list-style: none
     padding: 0

--- a/components/Event/TimeTable/index.vue
+++ b/components/Event/TimeTable/index.vue
@@ -34,11 +34,11 @@ export default {
     }),
     getTracks (day,no,room) {
       let currentDayTracks = this.talks.filter( (item, index) => {
-                                                if(item.day === day) return true
+                                                if(parseInt(item.day) === parseInt(day)) return true
                                                 })
       if(currentDayTracks[0]){
           return currentDayTracks.filter( (track) => {
-                                          if(track.no == no  && track.room_id == room ) return true
+                                          if(parseInt(track.no) === parseInt(no)  && String(track.room_id) === String(room) ) return true
                                           })[0]
       }
       return ""

--- a/components/Event/TimeTable/table.pug
+++ b/components/Event/TimeTable/table.pug
@@ -7,7 +7,7 @@ div#TimeTable
 
   div#tables.uk-switcher(v-scroll="fixedHead" v-elScroll="parallelScroll")
     section
-      div.t-head(ref="day-1" :class='{headFixed:isFixed}' uk-sticky="offset: 112; media: @s")
+      div.t-head(ref="day-1" :class='{headFixed:isFixed}' class="uk-visible@s" uk-sticky="offset: 112; media: @s" )
         ul.uk-flex
           li.t-time
           li {{ $t('event.conference.rooms.roomA') }} 
@@ -20,7 +20,7 @@ div#TimeTable
         tr.t-admission
           th
             time 9:30
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.regist') }} 
           td
@@ -75,14 +75,26 @@ div#TimeTable
         tr.t-lunch
           th
             time 12:00
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.lunch') }} 
           td
           td
           td
           td
-          td          
+          td
+        tr.t-sponsor-event
+          th.dotline
+            time 12:20
+          td
+          td
+          td
+          td.event
+            div.session-summary.uk-flex.uk-flex-column
+              span.room {{ $t('event.conference.rooms.roomD') }} 
+              p スポンサー企画
+          td
+          td
         tr
           th
             time 13:30
@@ -91,7 +103,7 @@ div#TimeTable
         tr.t-rest
           th
             time 14:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.break') }} 
           td
@@ -107,7 +119,7 @@ div#TimeTable
         tr.t-rest.t-snack
           th
             time 15:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.snack') }} 
           td
@@ -123,7 +135,7 @@ div#TimeTable
         tr.t-rest
           th
             time 16:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.break') }} 
           td
@@ -139,7 +151,7 @@ div#TimeTable
         tr.t-closing
           th
             time 17:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.closing') }} 
           td
@@ -150,7 +162,7 @@ div#TimeTable
         tr.t-party
           th
             time 17:30
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.lightningTalk') }} 
           td
@@ -161,7 +173,7 @@ div#TimeTable
         tr.t-party
           th
             time 18:00
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.party') }} 
           td
@@ -180,7 +192,7 @@ div#TimeTable
           td
 
     section
-      div#day-2-rooms.t-head(ref="day-2" :class='{headFixed:isFixed}' uk-sticky="offset: 112; media: @s")
+      div#day-2-rooms.t-head(ref="day-2" :class='{headFixed:isFixed}' class="uk-visible@s"  uk-sticky="offset: 112; media: @s")
         ul.uk-flex
           li.t-time
             li {{ $t('event.conference.rooms.roomA') }} 
@@ -194,7 +206,7 @@ div#TimeTable
         tr.t-admission
           th
             time 9:30
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.regist') }} 
           td
@@ -222,7 +234,7 @@ div#TimeTable
         tr.t-rest
           th
             time 11:00
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.break') }} 
           td
@@ -239,7 +251,7 @@ div#TimeTable
         tr.t-lunch
           th
             time 12:00
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.lunch') }} 
           td
@@ -256,7 +268,7 @@ div#TimeTable
         tr.t-rest
           th
             time 14:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.break') }} 
           td
@@ -270,10 +282,10 @@ div#TimeTable
             time 14:30
           td.t-session(v-for="room in rooms.dayTwo")
             SessionSummary.mini(:talk="getTracks(2,3,room)")
-        tr.t-rest
+        tr.t-rest.t-snack
           th
             time 15:00
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.snack') }} 
           td
@@ -290,7 +302,7 @@ div#TimeTable
         tr.t-rest
           th
             time 16:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.break') }} 
           td
@@ -307,7 +319,7 @@ div#TimeTable
         tr.t-party
           th
             time 17:15
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.lightningTalk') }} 
           td
@@ -319,7 +331,7 @@ div#TimeTable
         tr.t-closing
           th
             time 18:30
-          td
+          td.mass-event
             span.uk-flex.uk-flex-center
               p {{ $t('event.conference.timeEvent.closing') }} 
           td

--- a/components/Event/TimeTable/table.sass
+++ b/components/Event/TimeTable/table.sass
@@ -47,16 +47,27 @@
   #tables
     @media (max-width: 1340px)
       overflow-x: scroll
+      @media (max-width: $breakpoint-xsmall-max)
+        overflow-x: auto
     table
       width: 1296px
       border-spacing: 0
       font-weight: normal
+      @media (max-width: $breakpoint-xsmall-max)
+        width: 100%
+      td,th
+        @media (max-width: $breakpoint-xsmall-max)
+          display: block
       tr > th.t-time
         width: 4rem
       tr
         &:not(.t-head)
           th
             width: 4rem
+            @media (max-width: $breakpoint-xsmall-max)
+              width: 100%
+              margin: 0
+
       tr.t-head
         th
           &:not(.t-time)
@@ -76,14 +87,18 @@
         flex-direction: column
         align-items: flex-end
         padding: 0
-        &:after
-          content: ""
+        @media (max-width: $breakpoint-xsmall-max)
+          width: 100%
           display: block
-          width: 1rem
-          height: 1rem
-          margin: 0
-          margin-right: -.5rem
-          border-top: 1px solid #9B9B9B
+        &:after
+          @media (min-width: 639px)
+            content: ""
+            display: block
+            width: 1rem
+            height: 1rem
+            margin: 0
+            margin-right: -.5rem
+            border-top: 1px solid #9B9B9B
         time
           display: flex
           align-items: center
@@ -97,13 +112,23 @@
           text-align: center
           font-weight: 300
           padding-right: .9rem
+          @media (max-width: $breakpoint-xsmall-max)
+            position: static
+            width: 100%
+            justify-content: center
+            background-color: rgba(180,195,200,.3)
       td
         text-align: center
         border-top: 1px solid #9B9B9B
         background-color: #FFF
         vertical-align: top
+        @media (max-width: $breakpoint-xsmall-max)
+          border: none
         &:nth-child(even)
           background-color: rgba(180,195,200,.3)
+          @media (max-width: $breakpoint-xsmall-max)
+            background-color: #FFF
+
       .session-summary
         @include event-box
         span
@@ -139,12 +164,16 @@
           background: none
 
       tr.t-admission,
+      tr.t-lunch,
       tr.t-rest,
       tr.t-closing
           height: 60px
           td
             height: 60px
             position: relative
+            &:not(.mass-event)
+              @media (max-width: $breakpoint-xsmall-max)
+                height: 0
           span
             position: absolute
             top: 0
@@ -154,15 +183,20 @@
             height: calc(60px - 1px)
             align-items: center
             z-index: 2
+            @media (max-width: $breakpoint-xsmall-max)
+              width: calc(100% - .8rem)
             p
               margin: 0
-      tr.t-lunch,
+
       tr.t-snack,
       tr.t-party
           height: 100px
           td
             height: 100px
             position: relative
+            &:not(.mass-event)
+              @media (max-width: $breakpoint-xsmall-max)
+                height: 0
           span
             position: absolute
             top: 0
@@ -172,16 +206,73 @@
             height: calc(100px - 1px)
             align-items: center
             z-index: 2
+            @media (max-width: $breakpoint-xsmall-max)
+              width: 100%
             p
               margin: 0
 
+      tr.t-sponsor-event
+        height: 80px
+        th.dotline
+          &:after
+            @media (min-width: 639px)
+              content: ""
+              display: block
+              width: .6rem
+              height: 1rem
+              margin: 0
+              margin-right: -.2rem
+              border-top: 1px dotted #AAA
+          time
+            @media (max-width: $breakpoint-xsmall-max)
+              height: 50%
+              background-color: rgba(180,195,200,.2)
+              background-image: linear-gradient(90deg,rgba(180,195,200,.1) 50%, #fff 50%)
+              background-size: 3px 100%
+        td
+          border-top: 1px dotted #AAA
+          height: 80px
+          @media (max-width: $breakpoint-xsmall-max)
+            border: none
+            height: 120px
+            &:not(.event)
+              height: 0
+          &:not(.event)
+            padding: 0
+            &:after
+              @media (min-width: 639px)
+                content: ""
+                display: block
+                width: 100%
+                height: 120px
+                margin: 0
+                background-color: rgba(255,255,255,0.7)
+          div.session-summary
+            min-height: 100px
+            height: 100px
+            p
+              margin: 2.4rem 0 .2rem
     table#day-1
       td
         width: calc((1296px - 4rem) / 6)
+        @media (max-width: $breakpoint-xsmall-max)
+          width: 100%
 
     table#day-2
       td
         width: calc((1296px - 4rem) / 7)
+        @media (max-width: $breakpoint-xsmall-max)
+          width: 100%
+      tr.t-lunch
+          height: 100px
+          td
+            height: 100px
+            position: relative
+            &:not(.mass-event)
+              @media (max-width: $breakpoint-xsmall-max)
+                height: 0
+            span
+              height: calc(100px - 1px)
       tr.t-admission,
       tr.t-lunch,
       tr.t-rest,
@@ -189,6 +280,8 @@
       tr.t-party
           span
             width: calc((100% * 7) + 6px)
+            @media (max-width: $breakpoint-xsmall-max)
+              width: calc(100% - .8rem)
       tr.t-opening,
       tr.t-keynote,
       tr.t-session
@@ -239,3 +332,5 @@
 
   .mini
     width: calc((1296px - 9.9rem) / 7)
+    @media (max-width: $breakpoint-xsmall-max)
+      width: calc(100% - .8rem)

--- a/components/Event/TimeTable/table.sass
+++ b/components/Event/TimeTable/table.sass
@@ -287,17 +287,6 @@
       tr.t-session
           td
             position: relative
-          td.event > p,
-          td.connecting > div
-            @include event-box
-            position: absolute
-            top: 0
-            left: 0
-            background-color: #FFF
-            width: calc((100% * 2) - .6rem)
-            height: calc(100% - .8rem)
-            z-index: 2
-            margin: .4rem .3rem
           td.event > p
             align-items: center
 
@@ -315,6 +304,8 @@
               width: calc((100% * 2) - .6rem)
               z-index: 2
               margin: .4rem .3rem
+              @media (max-width: $breakpoint-xsmall-max)
+                position: static
 
     tr.t-opening
       td

--- a/locales/en.json
+++ b/locales/en.json
@@ -200,16 +200,16 @@
     "conference": {
       "title": "conference",
       "tab": {
-        "day1": "September 17th",
-        "day2": "September 18th"
+        "day1": "Sep. 17th",
+        "day2": "Sep. 18th"
       },
       "rooms": {
         "roomA": "A+B conference room",
-        "roomB": "small exhibition room",
+        "roomB": "small exhibition hall",
         "roomC": "Special conference room",
-        "roomD": "convention room",
-        "roomD2": "convention room  \b \"UME\" ",
-        "roomD3": "convention room \"UGUISU\"",
+        "roomD": "convention hall",
+        "roomD2": "convention  hall \"UME\" ",
+        "roomD3": "convention hall \"UGUISU\"",
         "roomE": "C conference room",
         "roomF": "D conference room"
       },

--- a/pages/_lang/code-of-conduct/index.sass
+++ b/pages/_lang/code-of-conduct/index.sass
@@ -1,2 +1,6 @@
 section#code-of-conduct
   margin: 0 20px
+  h2
+    @media (max-width: $breakpoint-small)
+      margin-bottom: 2rem
+      font-size: 36px

--- a/pages/_lang/event/conference.sass
+++ b/pages/_lang/event/conference.sass
@@ -1,8 +1,13 @@
 #Conference
   h2
-    //margin-bottom: 0
+    @media (max-width: $breakpoint-small)
+      margin: 0 20px 2rem
+      font-size: 36px
+
   p.warnning
     color: #a40014
     font-size: 14px
     margin-top: 0
     margin-bottom: 1rem
+    @media (max-width: $breakpoint-small)
+      margin: 10px 20px 3rem

--- a/store/index.js
+++ b/store/index.js
@@ -22,7 +22,7 @@ const sponsorApiUri = process.env.sponsorApiEndpoint + `?stage=${sponsorSheetNam
 
 /* for Session API's URI */
 let getSessinsAPIUri = () => {
-  const talkSheetName = 'dev'// Please change to "prod_yyyymmdd" if deploying production
+  const talkSheetName = 'dev_new'// Please change to "prod_yyyymmdd" if deploying production
   const talkNoCache = false  // Please change to "false" if deploying production
   let talkApiUri
   // chose endpoint

--- a/store/index.js
+++ b/store/index.js
@@ -22,7 +22,7 @@ const sponsorApiUri = process.env.sponsorApiEndpoint + `?stage=${sponsorSheetNam
 
 /* for Session API's URI */
 let getSessinsAPIUri = () => {
-  const talkSheetName = 'dev_new'// Please change to "prod_yyyymmdd" if deploying production
+  const talkSheetName = 'prod_20180826'// Please change to "prod_yyyymmdd" if deploying production
   const talkNoCache = false  // Please change to "false" if deploying production
   let talkApiUri
   // chose endpoint


### PR DESCRIPTION
# 変更点
- カンファレンスページのモバイル表示を追加（シングルカラム版
- 9月17日のスポンサー企画がタイムテーブルにはいっていなかったので追加
- 部屋名で「ホール」の英訳が「room」になっていたので「hall」に変更
- talkApiDataの参照シートをprod_20180826に変更