### PR TITLE
招待講演注意書きのモバイル版表示スタイル微修正

### DIFF
--- a/components/TopKeynote/keynote.sass
+++ b/components/TopKeynote/keynote.sass
@@ -13,6 +13,8 @@ section#TopKeynote
       margin-top: 0
       margin-bottom: 4rem
       margin-left: .2rem
+      @media (max-width: $breakpoint-xsmall-max)
+        margin: 0 calc(20px + .2rem) 4rem
 
     article.keynote-speakers,article.invited-speakers
         @media (max-width: 900px)


### PR DESCRIPTION
# 変更内容
- 招待講演追記のモバイル版の文字表示のマージンを誤ったので修正しました