### PR TITLE
uikitのモーダル使用時にノード構成が変わる挙動に対応

### DIFF
--- a/components/Event/SessionList/index.vue
+++ b/components/Event/SessionList/index.vue
@@ -27,6 +27,11 @@
       this.FETCH_TALK()
       this.FETCH_POSTER()
     },
+    destroyed(){
+      // !uikitのmodalを利用すると閉じたあとnodeの位置が変ってしまい、ページ遷移の度に元の位置にあった分のコンポーネントがロードされてしまうのでdestroyedの度に場外（になってるはず）のmodalを殺しておく。
+      let _modal = document.getElementById("modal-session")
+      if(_modal != undefined) _modal.remove()
+    },
     computed: {
       ...mapGetters({
         "talks": "talk_array",

--- a/components/Event/TimeTable/index.vue
+++ b/components/Event/TimeTable/index.vue
@@ -17,6 +17,7 @@ export default {
               "dayTwo": ["ra","rb","rc","rd2","rd3","re","rf"]
               },
       currentTalkDetail: {
+          category: "talk",
           talk: "",
           date: "",
           no: ""
@@ -29,6 +30,10 @@ export default {
   },
   mounted(){
     this.FETCH_TALK()
+  },
+  destroyed() {
+    let _modal = document.getElementById("modal-session")
+    if(_modal != undefined) _modal.remove()
   },
   computed: {
     ...mapGetters({


### PR DESCRIPTION
# 変更内容
- タイムテーブルなどでモーダルを表示→ページ遷移→もう一度タイムテーブルなどでモーダルを表示→2位回目以降ぐらいでモーダルの中身が違うバグの修正
----
 UIkitのモーダルを利用すると、モーダルを閉じたときにそのページのもっとも外側程にノードが移動する為、ページ遷移をして戻ってくるとモーダル用に入れていたタグが空と判定される→（ページ遷移の度に繰り返されるので）ノード複製地獄…になる為モーダルを読んでる親コンポーネントのdestroyedで逐一モーダル用のタグ（ノード）を削除するように設定