### PR TITLE
セッション一覧ページにLT追加他

### DIFF
--- a/components/Event/SessionDetail/detail.pug
+++ b/components/Event/SessionDetail/detail.pug
@@ -2,11 +2,13 @@ div#modal-session(uk-modal)
   div.detail-innter.uk-modal-dialog.uk-modal-body
     a.uk-modal-close-default(uk-close)
     div.talk-schedule
-      time(v-if="category === 'talk'") {{ dates }}
+      time(v-if="category === 'talk' || category === 'lt'") {{ dates }}
       time(v-if="category === 'poster'") {{ $t('event.conference.posterSummary.coretime') }}
       span.event-type(v-if="category === 'talk'") {{ $t('event.conference.sessionCategory.talk') }}({{ talk_format }})
+      span.event-type(v-if="category === 'lt'") {{ $t('event.conference.sessionCategory.lt') }}({{ $t('event.conference.ltSummary.talkTime') }})
       span.event-type(v-if="category === 'poster'") {{ $t('event.conference.sessionCategory.poster') }}
       span.room(v-if="category === 'talk'") {{ room }}
+      span.room(v-if="category === 'lt'") {{ $t('event.conference.ltSummary.room') }}
       span.room(v-if="category === 'poster'") {{ $t('event.conference.posterSummary.room') }}
     dl.talk-property.uk-flex.uk-flex-wrap
       dt.talk-langage(v-if="category === 'talk'") {{ $t('event.conference.sessionDetail.talkLanguage') }} :

--- a/components/Event/SessionDetail/index.vue
+++ b/components/Event/SessionDetail/index.vue
@@ -49,6 +49,9 @@
                 break
             }
           }
+        } else if( this.category === 'lt'){
+          _day = this.session.day === 1 ? "2018-9-17":"2018-9-18"
+          _time = this.session.no ? "no." + this.session.no : ""
         } else if( this.category === 'poster'){
           _day =  "2018-9-18"
           _time = "15:10 - 15:45"

--- a/components/Event/SessionList/index.vue
+++ b/components/Event/SessionList/index.vue
@@ -26,6 +26,7 @@
     mounted(){
       this.FETCH_TALK()
       this.FETCH_POSTER()
+      this.FETCH_LT()
     },
     destroyed(){
       // !uikitのmodalを利用すると閉じたあとnodeの位置が変ってしまい、ページ遷移の度に元の位置にあった分のコンポーネントがロードされてしまうのでdestroyedの度に場外（になってるはず）のmodalを殺しておく。
@@ -35,13 +36,15 @@
     computed: {
       ...mapGetters({
         "talks": "talk_array",
-        "posters": "poster_array"
+        "posters": "poster_array",
+        "lts": "lt_array",
       })
     },
     methods:{
       ...mapActions({
         FETCH_TALK: "FETCH_TALK",
-        FETCH_POSTER: "FETCH_POSTER"
+        FETCH_POSTER: "FETCH_POSTER",
+        FETCH_LT: "FETCH_LT"
       }),
       showDetail (category,session) {
         this.$data.currentSessionDetail.category = category

--- a/components/Event/SessionList/list.pug
+++ b/components/Event/SessionList/list.pug
@@ -16,7 +16,6 @@ article#session-lists
         li.uk-flex.uk-flex-wrap(v-for="talk in talks")
           sessionSummary(:session="talk" category="talk" isList="true" @summary-event="showDetail('talk',talk)")
 
-
     div#posters
       div.loading.uk-flex.uk-flex-center.uk-flex-column(v-if="posters == ''")
         div(uk-spinner="ratio:1.5")
@@ -28,5 +27,11 @@ article#session-lists
     div#Lts
       ul.sessions
         li.comingsoon coming soon
+      //div.loading.uk-flex.uk-flex-center.uk-flex-column(v-if="lts == ''")
+        div(uk-spinner="ratio:1.5")
+        p now loading
+      //ul.sessions
+        li.uk-flex.uk-flex-wrap(v-for="lt in lts")
+          sessionSummary(:session="lt" category="lt" isList="true" @summary-event="showDetail('lt',lt)")
 
   SessionDetail(:category="currentSessionDetail.category" :session="currentSessionDetail.session", :date="currentSessionDetail.date", :no="currentSessionDetail.no")

--- a/components/Event/SessionList/list.sass
+++ b/components/Event/SessionList/list.sass
@@ -17,7 +17,7 @@ article#session-lists
       @media (max-width: $breakpoint-xsmall-max)
         padding: 0
       li
-        border-bottom: 1px solid #9B9B9B
+        border-bottom: 1px solid #ddd
         padding: .7rem 0
         @media (max-width: $breakpoint-xsmall-max)
           padding: .7rem .5rem

--- a/components/Event/SessionSummary/index.vue
+++ b/components/Event/SessionSummary/index.vue
@@ -66,9 +66,14 @@
             }
           }
           return _day + " " + _time
+        } else if( this.category === 'lt'){
+          _day = this.session.day === 1 ? "2018-9-17":"2018-9-18"
+          _time = this.session.no ? "no." + this.session.no : ""
+
+          return _day + " " + _time
         } else if( this.category === 'poster'){
           _day =  "2018-9-18"
-          _time = "15:10 - 15:45"
+          _time = "15:00 - 15:45"
 
           return _day + " " + _time
         }

--- a/components/Event/SessionSummary/summary.pug
+++ b/components/Event/SessionSummary/summary.pug
@@ -3,14 +3,16 @@ div.session-summary.uk-flex.uk-flex-column(v-if="session")
   span.room(v-if="(category === 'talk') && !isList") {{ room }}
   span.event-type(v-if="(category === 'talk') && !isList") {{ talk_format }}
   div.talk-schedule.uk-flex.uk-flex-wrap(v-if="isList")
-    time(v-if="category === 'talk'") {{ dates }}
+    time(v-if="category === 'talk' || category === 'lt'") {{ dates }}
     time(v-if="category === 'poster'") {{ $t('event.conference.posterSummary.coretime') }}
     span.event-type(v-if="category === 'talk'") Talk({{ talk_format }})
+    span.event-type(v-if="category === 'lt'") LightningTalk({{ $t('event.conference.ltSummary.talkTime')}})
     span.room(v-if="category === 'talk'") {{ room }}
     span.room(v-if="category === 'poster'") {{ $t('event.conference.posterSummary.room') }}
+    span.room(v-if="category === 'lt'") {{ $t('event.conference.posterSummary.room') }}
     dl.talk-property.uk-flex.uk-flex-wrap
-      dt.talk-langage(v-if="category === 'talk'") {{ $t('event.conference.sessionDetail.talkLanguage') }}:
-      dd(v-if="category === 'talk'") {{ language }}
+      dt.talk-langage(v-if="category === 'talk' || category === 'lt'") {{ $t('event.conference.sessionDetail.talkLanguage') }}:
+      dd(v-if="category === 'talk' || category === 'lt'") {{ language }}
       dt.doc-langage(v-if="category === 'talk'") {{ $t('event.conference.sessionDetail.slideLanguage') }}:
       dd(v-if="category === 'talk'") {{ slide_language }}
       dt.talk-level {{ $t('event.conference.sessionDetail.audience') }}:

--- a/locales/en.json
+++ b/locales/en.json
@@ -223,6 +223,10 @@
       "posterSummary": {
           "coretime": "2018-09-18 15:00 - 15:40",
           "room": "Big Exhibition Hall"
+      },
+      "ltSummary": {
+          "talkTime": "5min",
+          "room": "Big Exhibition Hall"
       }
     },
     "sessions": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -86,7 +86,7 @@
       "foreigner": {
         "date": "September 17th",
         "name": "Manuel Kaufmann",
-        "theme": "\"Argentina in Python: community, dreams, travels and learning\"",
+        "theme": "Argentina in Python: community, dreams, travels and learning",
         "about": "Manuel Kaufmann met Python, while performing his university studies, at the PyDay Santa Fe (Argentina) event in 2006 and since that day his life changed forever, literally.\nHe fell in love with its syntax and forgot pointers and double-linked list of C to these days. \nSince then he has become an active member of Python Argentina (travels South America by car to spread Python) .\nIn these years, he has participated in the translation of the official book of Django and Django Girls Tutorial, among others. \nHe has also worked on projects like One Laptop Per Child and in February 2016 was named \"Python Ambassador\" by the Python Software Foundation for his work with Argentina in Python.\nCurrently he is working at Read the Docs as a software developer."
       }
     },
@@ -99,6 +99,7 @@
       "second": {
         "date": "September 17th",
         "name": "Kotaro Nakayama",
+        "theme": "東大松尾研流 実践的AI人材育成法",
         "about": "東京大学工学系研究科技術経営戦略学専攻 松尾研究室 リサーチディレクター。\n2007年に大阪大学大学院情報科学研究科博士号取得後、大阪大学情報科学研究科特任研究員、東京大学知の構造化センター助教、講師を経て、現在に至る。\n専門分野はAI、Web、大規模データ解析。"
       }
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -222,7 +222,7 @@
         "lt": "Lightning Talk"
       },
       "posterSummary": {
-          "coretime": "2018-09-18 15:00 - 15:40",
+          "coretime": "2018-09-18 15:15 - 15:40",
           "room": "Big Exhibition Hall"
       },
       "ltSummary": {

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -220,7 +220,11 @@
         "lt": "Lightning Talk"
       },
       "posterSummary": {
-          "coretime": "2018-09-18 15:00 - 15:40",
+          "coretime": "2018-09-18 15:00 - 15:45",
+          "room": "大展示ホール"
+      },
+      "ltSummary": {
+          "talkTime": "5min",
           "room": "大展示ホール"
       }
     },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -85,7 +85,7 @@
       "foreigner": {
         "date": "9月17日",
         "name": "Kaufmann Manuel",
-        "theme": "\"Argentina in Python: community, dreams, travels and learning\"",
+        "theme": "Argentina in Python: community, dreams, travels and learning",
         "about": "Manuel Kaufmannは、大学に在学中の2006年に開催されたPyDay Santa FeでPythonに出会った。\nそれによって彼の人生が大きく変わった。\n彼は、Pythonの文法が好きになり、C言語のポインターや双方向リストを数日で忘れるほどだった。\nその時から、Python Argentina（車で南米を旅行しPythonを広げる）のアクティブメンバーになった。\nしばらくして、Djangoの公式ドキュメントやDjango Girlsチュートリアルの翻訳に参加することになった。\n他にも、One Laptop Per Childのようなプロジェクトにも参加するようになった。\n彼のArgentina in Pythonの活動が、2016年2月にPSF Python Ambassadorとして表彰された。\n現在、Read the Docsでソフトウエアエンジニアとして働いている。"
       }
     },
@@ -98,7 +98,7 @@
       "second": {
         "date": "9月17日",
         "name": "中山 浩太郎",
-        "theme": "「東大松尾研流 実践的AI人材育成法」",
+        "theme": "東大松尾研流 実践的AI人材育成法",
         "about": "東京大学工学系研究科技術経営戦略学専攻 松尾研究室 リサーチディレクター。\n2007年に大阪大学大学院情報科学研究科博士号取得後、大阪大学情報科学研究科特任研究員、東京大学知の構造化センター助教、講師を経て、現在に至る。\n専門分野はAI、Web、大規模データ解析。"
       }
     },

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -220,7 +220,7 @@
         "lt": "Lightning Talk"
       },
       "posterSummary": {
-          "coretime": "2018-09-18 15:00 - 15:45",
+          "coretime": "2018-09-18 15:15 - 15:45",
           "room": "大展示ホール"
       },
       "ltSummary": {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -47,7 +47,7 @@ module.exports = {
     sponsorApiEndpoint: 'https://script.google.com/macros/s/AKfycbyKmE6Ew9aWmOnj3VSwn435T8cx8kF0SkJb9fN7_PdE_ME2QpqP/exec',
     talkApiEndpoint: 'https://script.google.com/macros/s/AKfycbyW6ECkWGiV6godDT9zWpwC2somqXW2UnTQfigMGAdJ2Uhy-50/exec',
     posterApiEndpoint: 'https://script.google.com/macros/s/AKfycbw9iy2_I5n5mxKcrX_wghzz18f5fUSdeROGpdic2Q/exec',
-    lightningTalklApiEndpoint: 'https://script.google.com/macros/s/AKfycbw6udsETgpLvHJxooAy1RjYKqQ0QECHITnT2oRHRA/exec'
+    ltApiEndpoint: 'https://script.google.com/macros/s/AKfycbw6udsETgpLvHJxooAy1RjYKqQ0QECHITnT2oRHRA/exec'
   },
   modules: [
     ['nuxt-sass-resources-loader', [

--- a/store/index.js
+++ b/store/index.js
@@ -34,7 +34,7 @@ let getSessinsAPIUri = (category) => {
     sheetName = 'prod_20180831'
     apiUri = process.env.talkApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }else if( category === 'poster'){
-    sheetName = 'dev'
+    sheetName = 'prod'
     apiUri = process.env.posterApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }else if( category === 'lt'){
     sheetName = 'dev'

--- a/store/index.js
+++ b/store/index.js
@@ -6,7 +6,8 @@ export const state = () => ({
   top_sponsor_array:[],
   top_sponsor_loading: 'enable',
   talk_array: [],
-  poster_array: []
+  poster_array: [],
+  lt_array: []
 })
 
 export const getters = {
@@ -15,7 +16,8 @@ export const getters = {
   top_sponsor_array (state) { return state.top_sponsor_array },
   top_sponsor_loading (state) { return state.top_sponsor_loading},
   talk_array (state) { return state.talk_array},
-  poster_array (state) { return state.poster_array}
+  poster_array (state) { return state.poster_array},
+  lt_array (state) { return state.lt_array}
 }
 
 const sponsorSheetName = 'prod_20180903'// Please change to "prod" if deploying production
@@ -29,12 +31,16 @@ let getSessinsAPIUri = (category) => {
   const noCache = false
 
   if(category === 'talk'){
-    sheetName = 'prod_20180831'// Please change to "prod_yyyymmdd" if deploying production
+    sheetName = 'prod_20180831'
     apiUri = process.env.talkApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }else if( category === 'poster'){
-    sheetName = 'dev'// Please change to "prod_yyyymmdd" if deploying production
+    sheetName = 'dev'
     apiUri = process.env.posterApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
+  }else if( category === 'lt'){
+    sheetName = 'dev'
+    apiUri = process.env.ltApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }
+
   return apiUri
 }
 
@@ -79,6 +85,13 @@ export const actions = {
     const json = await response.json()
     const data = json.data
     commit('FETCH_POSTER', data)
+  },
+  async FETCH_LT ({ commit }) {
+    const uri = getSessinsAPIUri('lt')
+    const response = await fetch(uri)
+    const json = await response.json()
+    const data = json.data
+    commit('FETCH_LT', data)
   }
 }
 
@@ -102,5 +115,8 @@ export const mutations = {
   },
   FETCH_POSTER(state, data) {
     state.poster_array = data
+  },
+  FETCH_LT(state, data) {
+    state.lt_array = data
   }
 }


### PR DESCRIPTION
# 変更内容
- セッション一覧(sessions）にLTのデータが取れるようにしました（ただし、スポンサーLTタイトル、日程の振り分けなど未確定情報などがある為、list.pugで出力用タグをコメントアウトし、「coming soon」表示のままにしています
- ポスターセッションのAPIデータ参照シートをprodに切り替え
- 文言、CSSの微修正