### PR TITLE
セッション一覧にLTの表示を追加

### DIFF
--- a/components/Event/SessionDetail/index.vue
+++ b/components/Event/SessionDetail/index.vue
@@ -50,7 +50,8 @@
             }
           }
         } else if( this.category === 'lt'){
-          _day = this.session.day === 1 ? "2018-9-17":"2018-9-18"
+          //_day = this.session.day === 1 ? "2018-9-17":"2018-9-18"
+          _day = this.session.day === 1 ? "2018-9-17 (17:30~) " : "2018-9-18 (17:15~) "
           _time = this.session.no ? "no." + this.session.no : ""
         } else if( this.category === 'poster'){
           _day =  "2018-9-18"

--- a/components/Event/SessionList/index.vue
+++ b/components/Event/SessionList/index.vue
@@ -37,7 +37,7 @@
       ...mapGetters({
         "talks": "talk_array",
         "posters": "poster_array",
-        "lts": "lt_array",
+        "lts": "lt_array"
       })
     },
     methods:{
@@ -55,7 +55,7 @@
         // show UIkit modal
         const uikit = require('uikit')
         uikit.modal('#modal-session').show()
-      },
+      }
     }
   }
 </script>

--- a/components/Event/SessionList/list.pug
+++ b/components/Event/SessionList/list.pug
@@ -24,13 +24,11 @@ article#session-lists
         li.uk-flex.uk-flex-wrap(v-for="poster in posters")
           sessionSummary(:session="poster" category="poster" isList="true" @summary-event="showDetail('poster',poster)")
 
-    div#Lts
-      ul.sessions
-        li.comingsoon coming soon
-      //div.loading.uk-flex.uk-flex-center.uk-flex-column(v-if="lts == ''")
+    div#lts
+      div.loading.uk-flex.uk-flex-center.uk-flex-column(v-if="lts == ''")
         div(uk-spinner="ratio:1.5")
         p now loading
-      //ul.sessions
+      ul.sessions
         li.uk-flex.uk-flex-wrap(v-for="lt in lts")
           sessionSummary(:session="lt" category="lt" isList="true" @summary-event="showDetail('lt',lt)")
 

--- a/components/Event/SessionSummary/index.vue
+++ b/components/Event/SessionSummary/index.vue
@@ -67,9 +67,8 @@
           }
           return _day + " " + _time
         } else if( this.category === 'lt'){
-          _day = this.session.day === 1 ? "2018-9-17":"2018-9-18"
+          _day = this.session.day === 1 ? "2018-9-17 (17:30~) " : "2018-9-18 (17:15~) "
           _time = this.session.no ? "no." + this.session.no : ""
-
           return _day + " " + _time
         } else if( this.category === 'poster'){
           _day =  "2018-9-18"

--- a/components/Event/SessionSummary/summary.pug
+++ b/components/Event/SessionSummary/summary.pug
@@ -11,8 +11,8 @@ div.session-summary.uk-flex.uk-flex-column(v-if="session")
     span.room(v-if="category === 'poster'") {{ $t('event.conference.posterSummary.room') }}
     span.room(v-if="category === 'lt'") {{ $t('event.conference.posterSummary.room') }}
     dl.talk-property.uk-flex.uk-flex-wrap
-      dt.talk-langage(v-if="category === 'talk' || category === 'lt'") {{ $t('event.conference.sessionDetail.talkLanguage') }}:
-      dd(v-if="category === 'talk' || category === 'lt'") {{ language }}
+      dt.talk-langage(v-if="category === 'talk'") {{ $t('event.conference.sessionDetail.talkLanguage') }}:
+      dd(v-if="category === 'talk'") {{ language }}
       dt.doc-langage(v-if="category === 'talk'") {{ $t('event.conference.sessionDetail.slideLanguage') }}:
       dd(v-if="category === 'talk'") {{ slide_language }}
       dt.talk-level {{ $t('event.conference.sessionDetail.audience') }}:

--- a/components/Event/mixins/sessionsMixin.js
+++ b/components/Event/mixins/sessionsMixin.js
@@ -13,7 +13,7 @@ export default {
       return (this.session && this.session.hasOwnProperty('name')) ?  this.session.name : ""
     },
     level () {
-      return (this.session && this.session.hasOwnProperty('audience_level') ) ?  this.session.audience_level : "-"
+      return (this.session && this.session.hasOwnProperty('audience_level') && this.session.audience_level != "") ?  this.session.audience_level : "-"
     },
     slide_language () {
       let _lang = ""

--- a/store/index.js
+++ b/store/index.js
@@ -17,7 +17,7 @@ export const getters = {
   top_sponsor_loading (state) { return state.top_sponsor_loading},
   talk_array (state) { return state.talk_array},
   poster_array (state) { return state.poster_array},
-  lt_array (state) {return state.lit_array},
+  lt_array (state) {return state.lt_array},
   news_list (state) { return state.news_list }
 }
 
@@ -29,7 +29,7 @@ const sponsorApiUri = process.env.sponsorApiEndpoint + `?stage=${sponsorSheetNam
 let getSessinsAPIUri = (category) => {
   let apiUri
   let sheetName
-  const noCache = false 
+  const noCache = false
 
   if(category === 'talk'){
     sheetName = 'prod_20180907'
@@ -38,7 +38,7 @@ let getSessinsAPIUri = (category) => {
     sheetName = 'prod'
     apiUri = process.env.posterApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }else if( category === 'lt'){
-    sheetName = 'dev'
+    sheetName = 'prod_20180911'
     apiUri = process.env.ltApiEndpoint + `?stage=${sheetName}&noCache=${noCache}`
   }
 
@@ -92,6 +92,13 @@ export const actions = {
     const response = await fetch(uri)
     const json = await response.json()
     const data = json.data
+    data.sort((a, b) => {
+        if (a.day < b.day) return -1
+        if (a.day > b.day) return 1
+        if (a.no < b.no) return -1
+        if (a.no > b.no) return 1
+        return 0
+    })
     commit('FETCH_LT', data)
   },
   async FETCH_NEWS ({ commit }) {


### PR DESCRIPTION
# 変更内容
- セッション一覧にLTのリスト表示を追加しました
※日付、noの順でソートしてあります
※発表言語については項目がないようなので表示しないようにしています
※スポンサーLTの方の発表詳細やプロフィールはもらっていないようなので「-」と表示されます